### PR TITLE
chores(depsync): update github.com/cryptellation/timeseries to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cryptellation/candlesticks v1.1.0
 	github.com/cryptellation/dbmigrator v1.0.1
 	github.com/cryptellation/health v1.2.0
-	github.com/cryptellation/timeseries v1.1.0
+	github.com/cryptellation/timeseries v1.2.0
 	github.com/cryptellation/version v1.4.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/cryptellation/health v1.2.0 h1:0j4k2VGRSgOTOX2ehrbcMQC9vkY5MLBuM0AaFR
 github.com/cryptellation/health v1.2.0/go.mod h1:V5JEOyvgWHMerjn5XyXllNSRHxCeCxKmWtT8YCz6W3c=
 github.com/cryptellation/timeseries v1.1.0 h1:S5xFLGukQg+k22+L5151Na95+WjhhDKMK0hBkxfJYgo=
 github.com/cryptellation/timeseries v1.1.0/go.mod h1:SxqmKOjn/l5AXZGaLGA47oScXzpTcXtnmfom88uZdaY=
+github.com/cryptellation/timeseries v1.2.0 h1:x90TnFhE3H4zPWEgLLekPMG7t611cnFvNU9DnFyCiD0=
+github.com/cryptellation/timeseries v1.2.0/go.mod h1:SxqmKOjn/l5AXZGaLGA47oScXzpTcXtnmfom88uZdaY=
 github.com/cryptellation/version v1.1.0 h1:guPP4DVPj0Ie1Fnmmiv3VM4xqG7ZMJGjvrS41mHg5Pc=
 github.com/cryptellation/version v1.1.0/go.mod h1:tKR3hxz6uB6AhgA0TKM3Qp6JNAgdQ2PcB0GGcsBWQvg=
 github.com/cryptellation/version v1.4.0 h1:xwtbfl2on1CyoiNYv+yo/uKqO1QMJ2pRmBz6+y0cFMg=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/timeseries** to version **v1.2.0**.

### Changes
- Updated dependency: `github.com/cryptellation/timeseries`
- New version: `v1.2.0`

This update was automatically generated by DepSync.